### PR TITLE
Code corrections to scripts (karazhan & stratholme)

### DIFF
--- a/src/modules/SD2/scripts/eastern_kingdoms/stratholme/instance_stratholme.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/stratholme/instance_stratholme.cpp
@@ -43,7 +43,8 @@ instance_stratholme::instance_stratholme(Map* pMap) : ScriptedInstance(pMap),
     m_uiYellCounter(0),
     m_uiMindlessCount(0),
     m_uiPostboxesUsed(0),
-    m_uiSilverHandKilled(0)
+    m_uiSilverHandKilled(0),
+    m_bTheUnforgivenSpawnHasTriggered(0)
 {
     Initialize();
 }
@@ -919,7 +920,7 @@ void instance_stratholme::Update(uint32 uiDiff)
 
     // Check to see if the spawning of The Unforgiven and its adds has been triggered by a player (player walking into area)
     // Once this has occurred, the respawning is dealt with via the creature object's respawn time (The Unforgiven every 30 minutes, Vengeful Phantoms every 15 minutes)
-    if (!bTheUnforgivenSpawnHasTriggered)
+    if (!m_bTheUnforgivenSpawnHasTriggered)
     {
         // Query the players in the instance
         Map::PlayerList const& players = instance->GetPlayers();
@@ -946,7 +947,7 @@ void instance_stratholme::Update(uint32 uiDiff)
                         pVengfulPhantom[i] = pPlayer->SummonCreature(NPC_VENGEFUL_PHANTOM, aStratholmeLocation[8].m_fX, aStratholmeLocation[8].m_fY, aStratholmeLocation[8].m_fZ, aStratholmeLocation[8].m_fO, TEMPSUMMON_CORPSE_TIMED_DESPAWN, 7200000);
                         pVengfulPhantom[i]->SetRespawnTime(900); // 15 minutes
                     }
-                    bTheUnforgivenSpawnHasTriggered = true;
+                    m_bTheUnforgivenSpawnHasTriggered = true;
                     break;
                 }
             }

--- a/src/modules/SD2/scripts/eastern_kingdoms/stratholme/stratholme.h
+++ b/src/modules/SD2/scripts/eastern_kingdoms/stratholme/stratholme.h
@@ -68,7 +68,7 @@ enum
     NPC_NEMAS_THE_ARBITER       = 17912,
     NPC_AELMAR_THE_VANQUISHER   = 17913,
     NPC_VICAR_HYERONIMUS        = 17914,
-    NPC_PALADIN_QUEST_CREDIT    = 17915,
+    NPC_PALADIN_QUEST_CREDIT	= 17915,
     NPC_THE_UNFORGIVEN          = 10516,
     NPC_VENGEFUL_PHANTOM        = 10387,                    // Adds for The Unforgiven
 
@@ -118,7 +118,7 @@ static const EventLocation aStratholmeLocation[] =
     {3969.357f, -3391.871f, 119.116f, 5.91f},               // Skeletons summon loc
     {4033.044f, -3431.031f, 119.055f},                      // Skeletons move loc
     {4032.602f, -3378.506f, 119.752f, 4.74f},               // Guards summon loc
-    {4042.575f, -3337.929f, 115.059f},                       // Ysida move 
+    {4042.575f, -3337.929f, 115.059f},                      // Ysida move loc
     {3713.681f, -3427.814f, 131.198f, 6.2f}                 // The Unforgiven spawn area
 };
 
@@ -186,7 +186,7 @@ class instance_stratholme : public ScriptedInstance
         GuidList m_luiGuardGUIDs;
 
         // this ensures that the code that deals with the initial spawning of The Unforgiven and its adds (Vengful Phantoms) is only run once
-        bool bTheUnforgivenSpawnHasTriggered = false;
+        bool m_bTheUnforgivenSpawnHasTriggered;
 };
 
 #endif


### PR DESCRIPTION
boss_netherspite (karazan), prefixed PortalProperties identifiers with
PORTAL_, due to clashing of EVENT identifier in an included file.

The Unforgiven (stratholme) - identifier initialisation of
m_bTheUnforgivenSpawnHasTriggered moved to instance_stratholme.cpp
