### PR TITLE
[Build] Get rid of two warnings

### DIFF
--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -56,7 +56,7 @@ uint32 mTimeStamp()
     t /= 10;
     t -= DELTA_EPOCH_IN_USEC;
 
-    return uint32((((t / 1000000L) * 1000) + ((t % 1000000L) / 1000)) - ((YEAR_IN_SECONDS * 20) * 1000));
+    return uint32((((t / 1000000L) * 1000) + ((t % 1000000L) / 1000)) - ((YEAR_IN_SECONDS * 20) * 1000LL));
 }
 
 #else

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -6216,6 +6216,7 @@ bool Spell::DoSummonPossessed(SpellEffectIndex eff_idx, uint32 forceFaction)
     if (Unit* summoner = m_originalCaster->ToUnit())
         sEluna->OnSummoned(spawnCreature, summoner);
 #endif /* ENABLE_ELUNA */
+    return true;
 }
 
 void Spell::EffectEnchantHeldItem(SpellEffectIndex eff_idx)


### PR DESCRIPTION
The long constant is in effect only in Win32 builds.
The bool return value never used, but should be returned anyway.
